### PR TITLE
polling is no longer triggered by cache

### DIFF
--- a/src/main/scala/it/bitrock/dvs/api/core/poller/FlightListKafkaPollerCache.scala
+++ b/src/main/scala/it/bitrock/dvs/api/core/poller/FlightListKafkaPollerCache.scala
@@ -2,7 +2,7 @@ package it.bitrock.dvs.api.core.poller
 
 import akka.actor.{ActorRef, ActorRefFactory, PoisonPill, Props, Terminated}
 import it.bitrock.dvs.api.config.KafkaConfig
-import it.bitrock.dvs.api.kafka.KafkaConsumerWrapper.{FlightListUpdate, NoMessage}
+import it.bitrock.dvs.api.kafka.KafkaConsumerWrapper.FlightListUpdate
 import it.bitrock.dvs.api.kafka.{KafkaConsumerWrapper, KafkaConsumerWrapperFactory}
 import it.bitrock.dvs.api.model._
 
@@ -25,14 +25,9 @@ class FlightListKafkaPollerCache(
   override def receive: Receive = active(FlightReceivedList(Seq()))
 
   def active(cache: FlightReceivedList): Receive = {
-    case NoMessage =>
-      logger.debug("Got no-message notice from Kafka Consumer, going to poll again")
-      schedulePoll()
-
     case flights: FlightReceivedList =>
       logger.debug(s"Got a $flights from Kafka Consumer")
       if (flights.elements.nonEmpty) context.become(active(flights))
-      schedulePoll()
 
     case FlightListUpdate => sender ! cache
 

--- a/src/main/scala/it/bitrock/dvs/api/core/poller/KafkaPoller.scala
+++ b/src/main/scala/it/bitrock/dvs/api/core/poller/KafkaPoller.scala
@@ -1,8 +1,7 @@
 package it.bitrock.dvs.api.core.poller
 
-import akka.actor.Actor
+import akka.actor.{Actor, Cancellable}
 import com.typesafe.scalalogging.LazyLogging
-import it.bitrock.dvs.api.ActorSystemOps
 import it.bitrock.dvs.api.config.KafkaConfig
 import it.bitrock.dvs.api.kafka.KafkaConsumerWrapper
 
@@ -14,17 +13,14 @@ trait KafkaPoller extends Actor with LazyLogging {
 
   val kafkaConsumerWrapper: KafkaConsumerWrapper
 
-  def schedulePoll(): Unit =
-    context.system.scheduleOnce(kafkaConfig.consumer.pollInterval)(kafkaConsumerWrapper.pollMessages())
-
-  override def preStart(): Unit = {
-    super.preStart()
-    logger.debug("Starting kafka message processor")
-    kafkaConsumerWrapper.pollMessages()
-  }
+  private val scheduledPoll: Cancellable =
+    context.system.scheduler.scheduleAtFixedRate(kafkaConfig.consumer.pollInterval, kafkaConfig.consumer.pollInterval)(() =>
+      kafkaConsumerWrapper.pollMessages()
+    )
 
   override def postStop(): Unit = {
     logger.debug("Stopping kafka message processor")
+    scheduledPoll.cancel()
     kafkaConsumerWrapper.close()
     super.postStop()
   }

--- a/src/main/scala/it/bitrock/dvs/api/core/poller/KafkaPoller.scala
+++ b/src/main/scala/it/bitrock/dvs/api/core/poller/KafkaPoller.scala
@@ -13,10 +13,16 @@ trait KafkaPoller extends Actor with LazyLogging {
 
   val kafkaConsumerWrapper: KafkaConsumerWrapper
 
-  private val scheduledPoll: Cancellable =
+  private lazy val scheduledPoll: Cancellable =
     context.system.scheduler.scheduleAtFixedRate(kafkaConfig.consumer.pollInterval, kafkaConfig.consumer.pollInterval)(() =>
       kafkaConsumerWrapper.pollMessages()
     )
+
+  override def preStart(): Unit = {
+    super.preStart()
+    logger.debug("Starting kafka message processor")
+    scheduledPoll
+  }
 
   override def postStop(): Unit = {
     logger.debug("Stopping kafka message processor")

--- a/src/main/scala/it/bitrock/dvs/api/core/poller/TopsKafkaPollerCache.scala
+++ b/src/main/scala/it/bitrock/dvs/api/core/poller/TopsKafkaPollerCache.scala
@@ -39,34 +39,25 @@ class TopsKafkaPollerCache(val kafkaConfig: KafkaConfig, kafkaConsumerWrapperFac
       speedCache: TopSpeedList,
       airlineCache: TopAirlineList
   ): Receive = {
-
-    case NoMessage =>
-      logger.debug("Got no-message notice from Kafka Consumer, going to poll again")
-      schedulePoll()
-
     case topArrivalAirportList: TopArrivalAirportList =>
       logger.debug(s"Got a $topArrivalAirportList from Kafka Consumer")
       if (topArrivalAirportList.elements.nonEmpty)
         context.become(active(topArrivalAirportList, departureCache, speedCache, airlineCache))
-      schedulePoll()
 
     case topDepartureAirportList: TopDepartureAirportList =>
       logger.debug(s"Got a $topDepartureAirportList from Kafka Consumer")
       if (topDepartureAirportList.elements.nonEmpty)
         context.become(active(arrivalCache, topDepartureAirportList, speedCache, airlineCache))
-      schedulePoll()
 
     case topSpeedList: TopSpeedList =>
       logger.debug(s"Got a $topSpeedList from Kafka Consumer")
       if (topSpeedList.elements.nonEmpty)
         context.become(active(arrivalCache, departureCache, topSpeedList, airlineCache))
-      schedulePoll()
 
     case topAirlineList: TopAirlineList =>
       logger.debug(s"Got a $topAirlineList from Kafka Consumer")
       if (topAirlineList.elements.nonEmpty)
         context.become(active(arrivalCache, departureCache, speedCache, topAirlineList))
-      schedulePoll()
 
     case TopArrivalAirportUpdate   => sender ! arrivalCache
     case TopDepartureAirportUpdate => sender ! departureCache

--- a/src/main/scala/it/bitrock/dvs/api/core/poller/TotalsKafkaPollerCache.scala
+++ b/src/main/scala/it/bitrock/dvs/api/core/poller/TotalsKafkaPollerCache.scala
@@ -26,19 +26,13 @@ class TotalsKafkaPollerCache(val kafkaConfig: KafkaConfig, kafkaConsumerWrapperF
   override def receive: Receive = active(TotalFlightsCount("", 0), TotalAirlinesCount("", 0))
 
   def active(flightCache: TotalFlightsCount, airlineCache: TotalAirlinesCount): Receive = {
-    case NoMessage =>
-      logger.debug("Got no-message notice from Kafka Consumer, going to poll again")
-      schedulePoll()
-
     case countFlight: TotalFlightsCount =>
       logger.debug(s"Got a $countFlight from Kafka Consumer")
       if (countFlight.eventCount > 0) context.become(active(countFlight, airlineCache))
-      schedulePoll()
 
     case countAirline: TotalAirlinesCount =>
       logger.debug(s"Got a $countAirline from Kafka Consumer")
       if (countAirline.eventCount > 0) context.become(active(flightCache, countAirline))
-      schedulePoll()
 
     case TotalFlightUpdate => sender ! flightCache
 

--- a/src/main/scala/it/bitrock/dvs/api/kafka/KafkaConsumerWrapper.scala
+++ b/src/main/scala/it/bitrock/dvs/api/kafka/KafkaConsumerWrapper.scala
@@ -11,7 +11,6 @@ import scala.collection.JavaConverters._
 
 object KafkaConsumerWrapper {
   sealed trait MessageUpdate
-  final case object NoMessage                 extends MessageUpdate
   final case object FlightListUpdate          extends MessageUpdate
   final case object TotalFlightUpdate         extends MessageUpdate
   final case object TotalAirlineUpdate        extends MessageUpdate

--- a/src/main/scala/it/bitrock/dvs/api/kafka/KafkaConsumerWrapperImpl.scala
+++ b/src/main/scala/it/bitrock/dvs/api/kafka/KafkaConsumerWrapperImpl.scala
@@ -20,8 +20,6 @@ class KafkaConsumerWrapperImpl[K: Deserializer, V: Deserializer](
 ) extends KafkaConsumerWrapper
     with LazyLogging {
 
-  import KafkaConsumerWrapper._
-
   val kafkaConsumer: KafkaConsumer[K, V] = getKafkaConsumer(conf, topics)
 
   // Startup rewind
@@ -30,11 +28,6 @@ class KafkaConsumerWrapperImpl[K: Deserializer, V: Deserializer](
   override def pollMessages(): Unit = {
     logger.debug("Going to poll for records")
     kafkaConsumer.poll(duration2JavaDuration(conf.consumer.pollInterval)).asScala match {
-      case l if l.isEmpty =>
-        logger.debug("Got no records")
-
-        processor ! NoMessage
-
       case results =>
         logger.debug(s"Got ${results.size} records")
 

--- a/src/test/scala/it/bitrock/dvs/api/TestProbeExtensions.scala
+++ b/src/test/scala/it/bitrock/dvs/api/TestProbeExtensions.scala
@@ -2,9 +2,9 @@ package it.bitrock.dvs.api
 
 import akka.testkit.TestProbe
 
-import scala.concurrent.duration.FiniteDuration
-
 object TestProbeExtensions {
+  import scala.concurrent.duration.FiniteDuration
+
   implicit class TestKitOps(tk: TestProbe) {
     def expectMessage[T](obj: T)(implicit timeout: FiniteDuration): T = tk.expectMsg(timeout, obj)
   }

--- a/src/test/scala/it/bitrock/dvs/api/TestProbeExtensions.scala
+++ b/src/test/scala/it/bitrock/dvs/api/TestProbeExtensions.scala
@@ -1,0 +1,11 @@
+package it.bitrock.dvs.api
+
+import akka.testkit.TestProbe
+
+import scala.concurrent.duration.FiniteDuration
+
+object TestProbeExtensions {
+  implicit class TestKitOps(tk: TestProbe) {
+    def expectMessage[T](obj: T)(implicit timeout: FiniteDuration): T = tk.expectMsg(timeout, obj)
+  }
+}

--- a/src/test/scala/it/bitrock/dvs/api/TestValues.scala
+++ b/src/test/scala/it/bitrock/dvs/api/TestValues.scala
@@ -101,8 +101,8 @@ trait TestValues {
   final val DefaultAirline5Name   = randomString(10)
   final val DefaultAirline5Amount = Random.nextLong
 
-  final val DefaultCountFlightAmount  = Random.nextLong
-  final val DefaultCountAirlineAmount = Random.nextLong
+  final val DefaultCountFlightAmount  = Math.abs(Random.nextLong)
+  final val DefaultCountAirlineAmount = Math.abs(Random.nextLong)
   final val DefaultStartTimeWindow    = randomString(10)
 
   final val coordinatesBox: String =

--- a/src/test/scala/it/bitrock/dvs/api/kafka/FlightListKafkaConsumerSpec.scala
+++ b/src/test/scala/it/bitrock/dvs/api/kafka/FlightListKafkaConsumerSpec.scala
@@ -4,9 +4,9 @@ import java.net.URI
 
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
+import it.bitrock.dvs.api.TestProbeExtensions._
 import it.bitrock.dvs.api.config.{AppConfig, KafkaConfig}
 import it.bitrock.dvs.api.kafka.FlightListKafkaConsumerSpec.Resource
-import it.bitrock.dvs.api.kafka.KafkaConsumerWrapper.NoMessage
 import it.bitrock.dvs.api.model._
 import it.bitrock.dvs.api.{BaseSpec, TestValues}
 import it.bitrock.dvs.model.avro.{
@@ -35,6 +35,7 @@ class FlightListKafkaConsumerSpec
     with TestValues {
 
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(6.seconds)
+  implicit private val akkaTimeout: FiniteDuration     = 250.millis
 
   "Kafka Consumer" should {
     "forward any record it reads from its subscribed topics to the configured processor, in order" in ResourceLoaner.withFixture {
@@ -174,7 +175,7 @@ class FlightListKafkaConsumerSpec
             publishToKafka(kafkaConfig.flightInterpolatedListTopic, "key", flightInterpolatedList)
             pollMessages()
 
-            processorProbe.expectMsg(expectedFlightReceivedList)
+            processorProbe.expectMessage(expectedFlightReceivedList)
           }
         }
     }
@@ -223,7 +224,7 @@ class FlightListKafkaConsumerSpec
 
           eventually {
             pollMessages()
-            processorProbe.expectMsg(NoMessage)
+            processorProbe.expectNoMessage()
           }
 
           val (_, response) =

--- a/src/test/scala/it/bitrock/dvs/api/kafka/TopsKafkaConsumerSpec.scala
+++ b/src/test/scala/it/bitrock/dvs/api/kafka/TopsKafkaConsumerSpec.scala
@@ -4,18 +4,18 @@ import java.net.URI
 
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
+import it.bitrock.dvs.api.TestProbeExtensions._
 import it.bitrock.dvs.api.config.{AppConfig, KafkaConfig}
-import it.bitrock.dvs.api.kafka.KafkaConsumerWrapper.NoMessage
 import it.bitrock.dvs.api.kafka.TopsKafkaConsumerSpec.Resource
 import it.bitrock.dvs.api.model._
 import it.bitrock.dvs.api.{BaseSpec, TestValues}
 import it.bitrock.dvs.model.avro.{
   TopAirline => KTopAirline,
-  TopAirport => KTopAirport,
-  TopSpeed => KTopSpeed,
   TopAirlineList => KTopAirlineList,
+  TopAirport => KTopAirport,
   TopArrivalAirportList => KTopArrivalAirportList,
   TopDepartureAirportList => KTopDepartureAirportList,
+  TopSpeed => KTopSpeed,
   TopSpeedList => KTopSpeedList
 }
 import it.bitrock.kafkacommons.serialization.ImplicitConversions._
@@ -36,6 +36,7 @@ class TopsKafkaConsumerSpec
     with BeforeAndAfterAll {
 
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(6.seconds)
+  implicit private val akkaTimeout: FiniteDuration     = 250.millis
 
   "Kafka Consumer" should {
 
@@ -93,7 +94,7 @@ class TopsKafkaConsumerSpec
               )
             )
             pollMessages()
-            processorProbe.expectMsg(expectedTopArrivalAirportList)
+            processorProbe.expectMessage(expectedTopArrivalAirportList)
           }
           eventually {
             publishToKafka(kafkaConfig.topDepartureAirportTopic, kTopDepartureAirportList)
@@ -107,7 +108,7 @@ class TopsKafkaConsumerSpec
               )
             )
             pollMessages()
-            processorProbe.expectMsg(expectedTopDepartureAirportList)
+            processorProbe.expectMessage(expectedTopDepartureAirportList)
           }
           eventually {
             publishToKafka(kafkaConfig.topSpeedTopic, kTopSpeedList)
@@ -121,7 +122,7 @@ class TopsKafkaConsumerSpec
               )
             )
             pollMessages()
-            processorProbe.expectMsg(expectedTopSpeedList)
+            processorProbe.expectMessage(expectedTopSpeedList)
           }
           eventually {
             publishToKafka(kafkaConfig.topAirlineTopic, kTopAirlineList)
@@ -135,7 +136,7 @@ class TopsKafkaConsumerSpec
               )
             )
             pollMessages()
-            processorProbe.expectMsg(expectedTopAirlineList)
+            processorProbe.expectMessage(expectedTopAirlineList)
           }
         }
 
@@ -192,7 +193,7 @@ class TopsKafkaConsumerSpec
 
           eventually {
             pollMessages()
-            processorProbe.expectMsg(NoMessage)
+            processorProbe.expectNoMessage()
           }
 
           val (_, responseArrivalAirport) =

--- a/src/test/scala/it/bitrock/dvs/api/kafka/TotalsKafkaConsumerSpec.scala
+++ b/src/test/scala/it/bitrock/dvs/api/kafka/TotalsKafkaConsumerSpec.scala
@@ -4,8 +4,8 @@ import java.net.URI
 
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
+import it.bitrock.dvs.api.TestProbeExtensions._
 import it.bitrock.dvs.api.config.{AppConfig, KafkaConfig}
-import it.bitrock.dvs.api.kafka.KafkaConsumerWrapper.NoMessage
 import it.bitrock.dvs.api.kafka.TotalsKafkaConsumerSpec.Resource
 import it.bitrock.dvs.api.model._
 import it.bitrock.dvs.api.{BaseSpec, TestValues}
@@ -28,6 +28,7 @@ class TotalsKafkaConsumerSpec
     with BeforeAndAfterAll {
 
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(6.seconds)
+  implicit private val akkaTimeout: FiniteDuration     = 250.millis
 
   "Kafka Consumer" should {
 
@@ -38,7 +39,7 @@ class TotalsKafkaConsumerSpec
           eventually {
             publishToKafka(kafkaConfig.totalFlightTopic, KCountFlight(DefaultStartTimeWindow, DefaultCountFlightAmount))
             pollMessages()
-            processorProbe.expectMsg(TotalFlightsCount(DefaultStartTimeWindow, DefaultCountFlightAmount))
+            processorProbe.expectMessage(TotalFlightsCount(DefaultStartTimeWindow, DefaultCountFlightAmount))
           }
           eventually {
             publishToKafka(
@@ -46,7 +47,7 @@ class TotalsKafkaConsumerSpec
               KCountAirline(DefaultStartTimeWindow, DefaultCountAirlineAmount)
             )
             pollMessages()
-            processorProbe.expectMsg(TotalAirlinesCount(DefaultStartTimeWindow, DefaultCountAirlineAmount))
+            processorProbe.expectMessage(TotalAirlinesCount(DefaultStartTimeWindow, DefaultCountAirlineAmount))
           }
         }
     }
@@ -64,7 +65,7 @@ class TotalsKafkaConsumerSpec
 
           eventually {
             pollMessages()
-            processorProbe.expectMsg(NoMessage)
+            processorProbe.expectNoMessage()
           }
 
           val (_, expectedValue) = consumeFirstKeyedMessageFrom[String, KCountFlight](kafkaConfig.totalFlightTopic)


### PR DESCRIPTION
Polling is now scheduled at a non overlapping fixed rate of `kafkaConfig.consumer.pollInterval` with an initial delay of `kafkaConfig.consumer.pollInterval`